### PR TITLE
Add option to disable clock events

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all:
 	    --env --env-types=$(CEU_DIR)/env/types.h                 \
 	          --env-threads=./env/threads.h                      \
 	          --env-main=$(CEU_DIR)/env/main.c                   \
-	    --cc --cc-args="-lm -llua5.3 -luv $(CFLAGS)"             \
+	    --cc --cc-args="-lm -llua5.3 -luv $(CC_ARGS)"            \
 	         --cc-output=/tmp/$$(basename $(CEU_SRC) .ceu);
 	/tmp/$$(basename $(CEU_SRC) .ceu);
 
@@ -36,7 +36,7 @@ samples:
 	        --env --env-types=$(CEU_DIR)/env/types.h                        \
 	              --env-threads=./env/threads.h                             \
 	              --env-main=$(CEU_DIR)/env/main.c                          \
-	        --cc --cc-args="$(LUA_FLAGS) -luv $(CFLAGS)"                    \
+	        --cc --cc-args="$(LUA_FLAGS) -luv $(CC_ARGS)"                   \
 	             --cc-output=/tmp/$$(basename $$i .ceu);                    \
 	    cd samples && /tmp/$$(basename $$i .ceu) ; cd ..                    \
 	    echo ">>> OK";                                                      \

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all:
 	    --env --env-types=$(CEU_DIR)/env/types.h                 \
 	          --env-threads=./env/threads.h                      \
 	          --env-main=$(CEU_DIR)/env/main.c                   \
-	    --cc --cc-args="-lm -llua5.3 -luv"                       \
+	    --cc --cc-args="-lm -llua5.3 -luv $(CFLAGS)"             \
 	         --cc-output=/tmp/$$(basename $(CEU_SRC) .ceu);
 	/tmp/$$(basename $(CEU_SRC) .ceu);
 
@@ -36,7 +36,7 @@ samples:
 	        --env --env-types=$(CEU_DIR)/env/types.h                        \
 	              --env-threads=./env/threads.h                             \
 	              --env-main=$(CEU_DIR)/env/main.c                          \
-	        --cc --cc-args="$(LUA_FLAGS) -luv"                              \
+	        --cc --cc-args="$(LUA_FLAGS) -luv $(CFLAGS)"                    \
 	             --cc-output=/tmp/$$(basename $$i .ceu);                    \
 	    cd samples && /tmp/$$(basename $$i .ceu) ; cd ..                    \
 	    echo ">>> OK";                                                      \

--- a/include/uv/uv.ceu
+++ b/include/uv/uv.ceu
@@ -39,6 +39,8 @@ native/pos do
     uv_check_t   ceu_uv_check;
     uv_prepare_t ceu_uv_prepare;
     uv_async_t   ceu_uv_async;
+
+##ifndef CEU_UV_WCLOCK_DISABLE
     uv_timer_t   ceu_uv_timer;
 
     u64 ceu_uv_timer_old;
@@ -54,6 +56,7 @@ native/pos do
         ceu_sys_assert(timer == &ceu_uv_timer, "bug found (UV: timer)");
         uv_async_send(&ceu_uv_async);
     }
+##endif
 
     void ceu_uv_check_cb (uv_check_t* check) {
         CEU_THREADS_MUTEX_LOCK(&CEU_APP.threads_mutex);
@@ -72,12 +75,16 @@ native/pos do
                 signal(SIGPIPE, SIG_IGN); // TODO: fails on "uv_write" would crash otherwise
                 uv_loop_init(&ceu_uv_loop);
                 uv_async_init(&ceu_uv_loop, &ceu_uv_async, NULL);
-                uv_timer_init(&ceu_uv_loop, &ceu_uv_timer);
-                ceu_uv_timer_old = uv_now(&ceu_uv_loop);
                 uv_check_init(&ceu_uv_loop, &ceu_uv_check);
                 uv_check_start(&ceu_uv_check, &ceu_uv_check_cb);
                 uv_prepare_init(&ceu_uv_loop, &ceu_uv_prepare);
                 uv_prepare_start(&ceu_uv_prepare, &ceu_uv_prepare_cb);
+
+##ifndef CEU_UV_WCLOCK_DISABLE
+                uv_timer_init(&ceu_uv_loop, &ceu_uv_timer);
+                ceu_uv_timer_old = uv_now(&ceu_uv_loop);
+##endif
+
                 break;
 
             case CEU_CALLBACK_STEP:
@@ -94,7 +101,7 @@ native/pos do
                 break;
             }
 
-##ifndef DISABLE_UV_CLOCK
+##ifndef CEU_UV_WCLOCK_DISABLE
             case CEU_CALLBACK_WCLOCK_DT:
                 ret.value.num = ceu_uv_dt();
                 break;

--- a/include/uv/uv.ceu
+++ b/include/uv/uv.ceu
@@ -94,6 +94,7 @@ native/pos do
                 break;
             }
 
+##ifndef DISABLE_UV_CLOCK
             case CEU_CALLBACK_WCLOCK_DT:
                 ret.value.num = ceu_uv_dt();
                 break;
@@ -111,6 +112,7 @@ native/pos do
                 }
                 break;
             }
+##endif
 
             default:
                 ret.is_handled = 0;


### PR DESCRIPTION
If the macro `DISABLE_UV_CLOCK` is defined, the lib won't generate
clock events. Ex:
```
make CEU_SRC=<SRC> CFLAGS=-DDISABLE_UV_CLOCK
```

* Makefile
* include/uv/uv.ceu